### PR TITLE
skip relationship_type_id validation

### DIFF
--- a/CRM/Csvimport/Task/Import.php
+++ b/CRM/Csvimport/Task/Import.php
@@ -171,6 +171,10 @@ class CRM_Csvimport_Task_Import {
     $opFields = array_keys($opFields);
     $valInfo = array();
     foreach ($params as $fieldName => $value) {
+      // exception with relation_type_id which is numeric, and doesn't pass the validation
+      if ($entity == 'Relationship' && $fieldName == 'relationship_type_id') {
+        continue;
+      }
       if(in_array($fieldName, $opFields)) {
         $valInfo[$fieldName] = self::validateField($entity, $fieldName, $value);
       }


### PR DESCRIPTION
In **CiviCRM 5.6.0**, importing Relationships doesn't work
A basic csv with "Contact A, Contact B, Relationship Type" fails to import on "Relationship Type" field

If a numeric values is in the field, the `validateField()` fails, because this field is treated as an options field, and it tries to match the numeric id against the labels
If the label is in the field, tha validation goes trhough, but the api create fails, because `Relationship.create` is expecting a numeric value for **relationship_type_id**

Not sure if my fix is the best solution to add this kind of exceptions.